### PR TITLE
refactor: change default dir and sync timestamp

### DIFF
--- a/main.py
+++ b/main.py
@@ -98,7 +98,7 @@ if __name__ == "__main__":
 
 
     ############### BASIC OPTION
-    arg('--data_path', type=str, default='data/', help='Data path를 설정할 수 있습니다.')
+    arg('--data_path', type=str, default='../data/', help='Data path를 설정할 수 있습니다.')
     arg('--saved_model_path', type=str, default='./saved_models', help='Saved Model path를 설정할 수 있습니다.')
     arg('--model', type=str, choices=['FM', 'FFM', 'NCF', 'WDN', 'DCN', 'CNN_FM', 'DeepCoNN'],
                                 help='학습 및 예측할 모델을 선택할 수 있습니다.')
@@ -120,7 +120,7 @@ if __name__ == "__main__":
     ############### WANDB OPTION
     arg('--project', type=str, default='book-rating-prediction')
     arg('--entity', type=str, default='recsys01')
-    arg('--name', type=str, default=f'work-{get_timestamp()}')
+    arg('--name', type=str, default=f'work-{setting.save_time}')
     
 
     ############### GPU

--- a/src/utils.py
+++ b/src/utils.py
@@ -10,7 +10,7 @@ from datetime import datetime, timedelta
 from .models import *
 
 
-def get_timestamp(date_format: str = '%Y-%m-%d-%H:%M:%S') -> str:
+def get_timestamp(date_format: str = '%y%m%d_%H%M%S') -> str:
     timestamp = datetime.now()
     return timestamp.strftime(date_format)
 
@@ -77,10 +77,7 @@ class Setting:
         torch.backends.cudnn.deterministic = True
 
     def __init__(self):
-        now = time.localtime()
-        now_date = time.strftime('%Y%m%d', now)
-        now_hour = time.strftime('%X', now)
-        save_time = now_date + '_' + now_hour.replace(':', '')
+        save_time = get_timestamp(date_format: str = '%y%m%d_%H%M%S')
         self.save_time = save_time
 
     def get_log_path(self, args):
@@ -110,7 +107,8 @@ class Setting:
         filename : submit file을 저장할 경로를 반환합니다.
         이 때, 파일명은 submit/날짜_시간_모델명.csv 입니다.
         '''
-        filename = f'./submit/{self.save_time}_{args.model}.csv'
+        path = self.make_dir('./submit/')
+        filename = f{path}{self.save_time}_{args.model}.csv'
         return filename
 
     def make_dir(self,path):


### PR DESCRIPTION
`issue`: #8 
---
default data_path를 수정했습니다.
* 이제 git clone한 directory에서 실행한다면 data_path를 인자로 넣어줄 필요가 없습니다.

submit.csv 생성시 make_dir를 추가하여 OSError를 해결했습니다.
* 이제 submit directory가 없다면 자동으로 생성됩니다. 

timestamp sync를 맞췄습니다.
* 이제 main 함수에서 setting을 생성할 때 init된 timestamp로 모든 save file name과 wandb name을 지정합니다.