### PR TITLE
refactor: change wandb log arguments

### DIFF
--- a/src/train/trainer.py
+++ b/src/train/trainer.py
@@ -56,7 +56,7 @@ def train(args, model, dataloader, logger, setting):
         valid_loss = valid(args, model, dataloader, loss_fn)
         print(f'Epoch: {epoch+1}, Train_loss: {total_loss/batch:.3f}, valid_loss: {valid_loss:.3f}')
         logger.log(epoch=epoch+1, train_loss=total_loss/batch, valid_loss=valid_loss)
-        wandb.log({'epoch': epoch, 'val_loss': valid_loss})
+        wandb.log({'epoch': epoch+1, 'tra_loss': train_loss, 'val_loss': valid_loss})
         if minimum_loss > valid_loss:
             minimum_loss = valid_loss
             os.makedirs(args.saved_model_path, exist_ok=True)


### PR DESCRIPTION
issue: #20 
---
* `wandb.log`의 딕셔너리를 수정했습니다.
* 이제 `epoch`이 `0`부터 `epochs` 까지 로깅 됩니다.
* metric으로 `train_loss`를 추가했습니다. 이제 `train_loss`과 `valid_loss`를 비교하여 모델이 언제 과적합 되는지 모니터링할 수 있습니다.