### PR TITLE
feat: add Huber Loss to loss_fn choices

### DIFF
--- a/main.py
+++ b/main.py
@@ -124,7 +124,7 @@ if __name__ == "__main__":
     arg('--batch_size', type=int, default=1024, help='Batch size를 조정할 수 있습니다.')
     arg('--epochs', type=int, default=10, help='Epoch 수를 조정할 수 있습니다.')
     arg('--lr', type=float, default=1e-3, help='Learning Rate를 조정할 수 있습니다.')
-    arg('--loss_fn', type=str, default='RMSE', choices=['MSE', 'RMSE'], help='손실 함수를 변경할 수 있습니다.')
+    arg('--loss_fn', type=str, default='RMSE', choices=['MSE', 'RMSE', 'Huber'], help='손실 함수를 변경할 수 있습니다.')
     arg('--optimizer', type=str, default='ADAM', choices=['SGD', 'ADAM'], help='최적화 함수를 변경할 수 있습니다.')
     arg('--weight_decay', type=float, default=1e-6, help='Adam optimizer에서 정규화에 사용하는 값을 조정할 수 있습니다.')
 

--- a/src/train/trainer.py
+++ b/src/train/trainer.py
@@ -4,7 +4,7 @@ import wandb
 import pandas as pd
 import torch
 import torch.nn as nn
-from torch.nn import MSELoss
+from torch.nn import MSELoss, HuberLoss
 from torch.optim import SGD, Adam
 
 
@@ -24,6 +24,8 @@ def train(args, model, dataloader, logger, setting):
         loss_fn = MSELoss()
     elif args.loss_fn == 'RMSE':
         loss_fn = RMSELoss()
+    elif args.loss_fn == 'Huber':
+        loss_fn = HuberLoss()
     else:
         pass
     if args.optimizer == 'SGD':


### PR DESCRIPTION
`issue:` #21 
---
* Huber Loss를 loss_fn 선택지로 추가했습니다.
* 이제 `python main.py --model {모델명} --loss_fn Huber` 명령어를 통해 Huber Loss로 학습할 수 있습니다.