### PR TITLE
feat: books 데이터 카테고리 선택 기능 추가

### DIFF
--- a/main.py
+++ b/main.py
@@ -120,6 +120,7 @@ if __name__ == "__main__":
     arg('--test_size', type=float, default=0.2, help='Train/Valid split 비율을 조정할 수 있습니다.')
     arg('--seed', type=int, default=42, help='seed 값을 조정할 수 있습니다.')
     arg('--use_best_model', type=bool, default=True, help='검증 성능이 가장 좋은 모델 사용여부를 설정할 수 있습니다.')
+    arg('--book_cat', type=str, default='basic', choices=['basic', 'high'], help='books 데이터의 카테고리를 선택할 수 있습니다.')
 
 
     ############### TRAINING OPTION


### PR DESCRIPTION
books.csv 에서 category 필드의 약 절반이 결측치였기 때문에, 이로 인한 성능 저하 문제를 해결하고자 category_high 라는 상위 카테고리 필드를 생성하여 유사한 책끼리 묶어서 해당 category로 채워넣었습니다.
categorh_high 필드가 추가된 데이터셋: https://drive.google.com/file/d/1wMFGUEz8Pp40YG7v_rtccGf0S1o4lpTc/view?usp=sharing

그리고 모델 학습시 어떤 카테고리를 사용할 지 선택할 수 있도록 기능을 추가하였습니다.

명령어 옵션 예시(default): --books_cat basic
명령어 옵션 예시: --books_cat high
