### PR TITLE
feat : Age의 결측값 처리 방식 선택 기능 추가

### DIFF
--- a/main.py
+++ b/main.py
@@ -133,8 +133,8 @@ if __name__ == "__main__":
     arg('--test_size', type=float, default=0.2, help='Train/Valid split 비율을 조정할 수 있습니다.')
     arg('--seed', type=int, default=42, help='seed 값을 조정할 수 있습니다.')
     arg('--use_best_model', type=bool, default=True, help='검증 성능이 가장 좋은 모델 사용여부를 설정할 수 있습니다.')
-    arg('--book_cat', type=str, default='basic', choices=['basic', 'high'], help='books 데이터의 카테고리를 선택할 수 있습니다.')
-
+    arg('--process_cat', type=str, default='basic', choices=['basic', 'high'], help='books 데이터의 카테고리를 선택할 수 있습니다.')
+    arg('--process_age', type=str, default='global_mean', choices=['global_mean', 'zero_cat', 'loc_mean', 'rand_norm'], help='데이터의 결측치를 처리할 방법을 선택할 수 있습니다.')
 
     ############### TRAINING OPTION
     arg('--batch_size', type=int, default=1024, help='Batch size를 조정할 수 있습니다.')


### PR DESCRIPTION
모델 실행시 Age 결측치를 처리할 수 있는 방법 4가지를 추가했습니다.

global_mean : 전체 데이터의 평균으로 대체
zero_cat : mapping시 0으로 처리
loc_mean : location information을 활용해 대체
rand_norm : normal dist에서 랜덤하게 뽑아서 대체

명령어 옵션 예시(default): --process_cat global_mean
명령어 옵션 예시: --process_cat zero_cat

#32 에서의 인자 이름 ' books_cat '를 통일성을 위해 'process_cat'로 변경하였습니다. 