### PR TITLE
chore: add submit, models in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@ ipython_config.py
 .log
 log
 wandb
+submit
+saved_models
 
 # MacOS
 .DS_Store


### PR DESCRIPTION
gitignore 파일에 submit 과 saved_models를 추가하여, 더이상 추적되지 않도록 하였습니다.

- submit 폴더: 대회 제출 파일과 예측 결과 분석을 위한 valid.csv 파일이 저장되는 폴더입니다.
- saved_models 폴더: 학습된 모델의 가중치 정보 파일(.pt)이 저장되는 폴더입니다.
