### PR TITLE
fix: add 'None' in sampler choices for sweep

### DIFF
--- a/main.py
+++ b/main.py
@@ -164,7 +164,7 @@ if __name__ == "__main__":
     arg('--process_cat', type=str, default='basic', choices=['basic', 'high'], help='books 데이터의 카테고리를 선택할 수 있습니다.')
     arg('--process_age', type=str, default='global_mean', choices=['global_mean', 'zero_cat','stratified', 'loc_mean', 'rand_norm'], help='데이터의 결측치를 처리할 방법을 선택할 수 있습니다.')
     arg('--process_loc', type=str, nargs='+', default=['city', 'state', 'country'], choices=['none', 'city', 'state', 'country'], help='usesr의 location을 구분할 기준을 선택할 수 있습니다. none을 선택하면 location은 drop됩니다.')
-    arg('--sampler', type=str, default=None, choices=['weighted'], help='dataloader의 sampler를 변경할 수 있습니다.')
+    arg('--sampler', type=str, default=None, choices=[None, 'None', 'weighted'], help='dataloader의 sampler를 변경할 수 있습니다.')
 
     ############### TRAINING OPTION
     arg('--batch_size', type=int, default=1024, help='Batch size를 조정할 수 있습니다.')

--- a/src/utils.py
+++ b/src/utils.py
@@ -15,7 +15,7 @@ from .models import *
 
 
 def get_sampler(args, y):
-    if args.sampler == None:
+    if (args.sampler == None) or (args.sampler == 'None'):
         sampler = None
     elif args.sampler == 'weighted': 
         labels = list(y)


### PR DESCRIPTION
* sampler args choices에 `None`과 `'None'`을 추가했습니다.
* 이제 `--sampler None` 이나 `--sampler 'None'` 을 입력하면 dataloader가 batch를 생성할 때 sampler를 사용하지않습니다.
* `sweep`에서도 정상적으로 동작할 것으로 예상됩니다.