### PR TITLE
refactor: change cross validation process

### DIFF
--- a/main.py
+++ b/main.py
@@ -109,9 +109,11 @@ def main(args):
     ######################## TRAIN
     print(f'--------------- {args.model} TRAINING ---------------')
     if args.cross_validation:
-        model = cv_train(args, model, data, loss_fn, optimizer, logger, setting)
+        model, cv_score = cv_train(args, model, data, loss_fn, optimizer, logger, setting)
+        print(f"cv_score is {cv_score:4f}")
     else:
-        model = train(args, model, data, loss_fn, optimizer, logger, setting)
+        model, minimum_loss = train(args, model, data, loss_fn, optimizer, logger, setting)
+        print(f"minimum_loss is {minimum_loss:4f}")
 
 
     ######################## INFERENCE
@@ -169,7 +171,7 @@ if __name__ == "__main__":
     arg('--process_cat', type=str, default='basic', choices=['basic', 'high'], help='books 데이터의 카테고리를 선택할 수 있습니다.')
     arg('--process_age', type=str, default='global_mean', choices=['global_mean', 'zero_cat','stratified', 'loc_mean', 'rand_norm'], help='데이터의 결측치를 처리할 방법을 선택할 수 있습니다.')
     arg('--process_loc', type=str, nargs='+', default=['city', 'state', 'country'], choices=['none', 'city', 'state', 'country'], help='usesr의 location을 구분할 기준을 선택할 수 있습니다. none을 선택하면 location은 drop됩니다.')
-    arg('--sampler', type=str, default=None, choices=[None, 'None', 'weighted'], help='dataloader의 sampler를 변경할 수 있습니다.')
+    arg('--sampler', type=str, default=None, choices=['None', None, 'weighted'], help='dataloader의 sampler를 변경할 수 있습니다.')
 
     ############### TRAINING OPTION
     arg('--batch_size', type=int, default=1024, help='Batch size를 조정할 수 있습니다.')

--- a/src/data/context_data.py
+++ b/src/data/context_data.py
@@ -312,15 +312,15 @@ def context_data_loader(args, data):
             data shuffle 여부
     ----------
     """
-
+    whole_dataset = TensorDataset(torch.LongTensor(data['train'].drop(['rating'], axis=1).values), torch.LongTensor(data['train']['rating'].values))
     train_dataset = TensorDataset(torch.LongTensor(data['X_train'].values), torch.LongTensor(data['y_train'].values))
     valid_dataset = TensorDataset(torch.LongTensor(data['X_valid'].values), torch.LongTensor(data['y_valid'].values))
     test_dataset = TensorDataset(torch.LongTensor(data['test'].values))
 
-    train_dataloader = DataLoader(train_dataset, batch_size=args.batch_size, shuffle=False, num_workers=4, sampler=get_sampler(args, data['y_train'].values))
+    train_dataloader = DataLoader(train_dataset, batch_size=args.batch_size, shuffle=False, num_workers=4, sampler=get_sampler(args, train_dataset, data['y_train'].values))
     valid_dataloader = DataLoader(valid_dataset, batch_size=args.batch_size, shuffle=False, num_workers=4)
     test_dataloader = DataLoader(test_dataset, batch_size=args.batch_size, shuffle=False, num_workers=4)
 
-    data['train_dataloader'], data['valid_dataloader'], data['test_dataloader'] = train_dataloader, valid_dataloader, test_dataloader
+    data['whole_dataset'], data['train_dataloader'], data['valid_dataloader'], data['test_dataloader'] = whole_dataset, train_dataloader, valid_dataloader, test_dataloader
 
     return data

--- a/src/data/dl_data.py
+++ b/src/data/dl_data.py
@@ -91,15 +91,15 @@ def dl_data_loader(args, data):
             data shuffle 여부
     ----------
     """
-
+    whole_dataset = TensorDataset(torch.LongTensor(data['train'].drop(['rating'], axis=1).values), torch.LongTensor(data['train']['rating'].values))
     train_dataset = TensorDataset(torch.LongTensor(data['X_train'].values), torch.LongTensor(data['y_train'].values))
     valid_dataset = TensorDataset(torch.LongTensor(data['X_valid'].values), torch.LongTensor(data['y_valid'].values))
     test_dataset = TensorDataset(torch.LongTensor(data['test'].values))
 
-    train_dataloader = DataLoader(train_dataset, batch_size=args.batch_size, shuffle=False, num_workers=4, sampler=get_sampler(args, data['y_train'].values))
+    train_dataloader = DataLoader(train_dataset, batch_size=args.batch_size, shuffle=False, num_workers=4, sampler=get_sampler(args, train_dataset, data['y_train'].values))
     valid_dataloader = DataLoader(valid_dataset, batch_size=args.batch_size, shuffle=False, num_workers=4)
     test_dataloader = DataLoader(test_dataset, batch_size=args.batch_size, shuffle=False, num_workers=4)
 
-    data['train_dataloader'], data['valid_dataloader'], data['test_dataloader'] = train_dataloader, valid_dataloader, test_dataloader
+    data['whole_dataset'], data['train_dataloader'], data['valid_dataloader'], data['test_dataloader'] = whole_dataset, train_dataloader, valid_dataloader, test_dataloader
 
     return data

--- a/src/data/image_context_data.py
+++ b/src/data/image_context_data.py
@@ -90,6 +90,11 @@ def image_context_data_loader(args, data):
         image_context_data_split로 부터 학습/평가/실험 데이터가 담긴 사전 형식의 데이터를 입력합니다.
     ----------
     """
+    whole_dataset = Image_Dataset(
+                                data['train'].drop(['img_vector', 'rating'], axis=1).values,
+                                data['train']['img_vector'].values,
+                                data['train']['rating'].values
+                                )
     train_dataset = Image_Dataset(
                                 data['X_train'].drop(['img_vector'], axis=1).values,
                                 data['X_train']['img_vector'].values,
@@ -106,8 +111,8 @@ def image_context_data_loader(args, data):
                                 data['test']['rating'].values
                                 )
 
-    train_dataloader = DataLoader(train_dataset, batch_size=args.batch_size, num_workers=4, shuffle=False, sampler=get_sampler(args, data['y_train'].values))
+    train_dataloader = DataLoader(train_dataset, batch_size=args.batch_size, num_workers=4, shuffle=False, sampler=get_sampler(args, train_dataset, data['y_train'].values))
     valid_dataloader = DataLoader(valid_dataset, batch_size=args.batch_size, num_workers=4, shuffle=False)
     test_dataloader = DataLoader(test_dataset, batch_size=args.batch_size, num_workers=4, shuffle=False)
-    data['train_dataloader'], data['valid_dataloader'], data['test_dataloader'] = train_dataloader, valid_dataloader, test_dataloader
+    data['whole_dataset'], data['train_dataloader'], data['valid_dataloader'], data['test_dataloader'] = whole_dataset, train_dataloader, valid_dataloader, test_dataloader
     return data

--- a/src/data/image_data.py
+++ b/src/data/image_data.py
@@ -195,6 +195,11 @@ def image_data_loader(args, data):
         image_data_split로 부터 학습/평가/실험 데이터가 담긴 사전 형식의 데이터를 입력합니다.
     ----------
     """
+    whole_dataset = Image_Dataset(
+                                data['img_train'][['user_id', 'isbn']].values,
+                                data['img_train']['img_vector'].values,
+                                data['img_train']['rating'].values
+                                )
     train_dataset = Image_Dataset(
                                 data['X_train'][['user_id', 'isbn']].values,
                                 data['X_train']['img_vector'].values,
@@ -211,8 +216,8 @@ def image_data_loader(args, data):
                                 data['img_test']['rating'].values
                                 )
 
-    train_dataloader = torch.utils.data.DataLoader(train_dataset, batch_size=args.batch_size, num_workers=4, shuffle=False, sampler=get_sampler(args, data['y_train'].values))
+    train_dataloader = torch.utils.data.DataLoader(train_dataset, batch_size=args.batch_size, num_workers=4, shuffle=False, sampler=get_sampler(args, train_dataset, data['y_train'].values))
     valid_dataloader = torch.utils.data.DataLoader(valid_dataset, batch_size=args.batch_size, num_workers=4, shuffle=False)
     test_dataloader = torch.utils.data.DataLoader(test_dataset, batch_size=args.batch_size, num_workers=4, shuffle=False)
-    data['train_dataloader'], data['valid_dataloader'], data['test_dataloader'] = train_dataloader, valid_dataloader, test_dataloader
+    data['whole_dataset'], data['train_dataloader'], data['valid_dataloader'], data['test_dataloader'] = whole_dataset, train_dataloader, valid_dataloader, test_dataloader
     return data

--- a/src/data/image_text_data.py
+++ b/src/data/image_text_data.py
@@ -133,6 +133,13 @@ def image_text_data_loader(args, data):
         image_text_data_split로 부터 학습/평가/실험 데이터가 담긴 사전 형식의 데이터를 입력합니다.
     ----------
     """
+    whole_dataset = Image_Text_Dataset(
+                                data['train'][['user_id', 'isbn']].values,
+                                data['train']['user_summary_merge_vector'].values,
+                                data['train']['item_summary_vector'].values,
+                                data['train']['img_vector'].values,
+                                data['train']['rating'].values
+                                )
     train_dataset = Image_Text_Dataset(
                                 data['X_train'][['user_id', 'isbn']].values,
                                 data['X_train']['user_summary_merge_vector'].values,
@@ -155,8 +162,8 @@ def image_text_data_loader(args, data):
                                 data['test']['rating'].values
                                 )
 
-    train_dataloader = DataLoader(train_dataset, batch_size=args.batch_size, num_workers=4, shuffle=False, sampler=get_sampler(args, data['y_train'].values))
+    train_dataloader = DataLoader(train_dataset, batch_size=args.batch_size, num_workers=4, shuffle=False, sampler=get_sampler(args, train_dataset, data['y_train'].values))
     valid_dataloader = DataLoader(valid_dataset, batch_size=args.batch_size, num_workers=4, shuffle=False)
     test_dataloader = DataLoader(test_dataset, batch_size=args.batch_size, num_workers=4, shuffle=False)
-    data['train_dataloader'], data['valid_dataloader'], data['test_dataloader'] = train_dataloader, valid_dataloader, test_dataloader
+    data['whole_dataset'], data['train_dataloader'], data['valid_dataloader'], data['test_dataloader'] = whole_dataset, train_dataloader, valid_dataloader, test_dataloader
     return data

--- a/src/data/text_data.py
+++ b/src/data/text_data.py
@@ -299,6 +299,12 @@ def text_data_loader(args, data):
         text_data_split로 부터 학습/평가/실험 데이터가 담긴 사전 형식의 데이터를 입력합니다.
     ----------
     """
+    whole_dataset = Text_Dataset(
+                                data['text_train'][['user_id', 'isbn']].values,
+                                data['text_train']['user_summary_merge_vector'].values,
+                                data['text_train']['item_summary_vector'].values,
+                                data['text_train']['rating'].values
+                                )
     train_dataset = Text_Dataset(
                                 data['X_train'][['user_id', 'isbn']].values,
                                 data['X_train']['user_summary_merge_vector'].values,
@@ -319,8 +325,8 @@ def text_data_loader(args, data):
                                 )
 
 
-    train_dataloader = torch.utils.data.DataLoader(train_dataset, batch_size=args.batch_size, num_workers=4, shuffle=False, sampler=get_sampler(args, data['y_train'].values))
+    train_dataloader = torch.utils.data.DataLoader(train_dataset, batch_size=args.batch_size, num_workers=4, shuffle=False, sampler=get_sampler(args, train_dataset, data['y_train'].values))
     valid_dataloader = torch.utils.data.DataLoader(valid_dataset, batch_size=args.batch_size, num_workers=4, shuffle=False)
     test_dataloader = torch.utils.data.DataLoader(test_dataset, batch_size=args.batch_size, num_workers=4, shuffle=False)
-    data['train_dataloader'], data['valid_dataloader'], data['test_dataloader'] = train_dataloader, valid_dataloader, test_dataloader
+    data['whole_dataset'], data['train_dataloader'], data['valid_dataloader'], data['test_dataloader'] = whole_dataset, train_dataloader, valid_dataloader, test_dataloader
     return data

--- a/src/utils.py
+++ b/src/utils.py
@@ -10,15 +10,15 @@ import pandas as pd
 from datetime import datetime, timedelta
 from torch.nn import MSELoss, HuberLoss
 from torch.optim import SGD, Adam
-from torch.utils.data.sampler import WeightedRandomSampler
+from torch.utils.data.sampler import RandomSampler, WeightedRandomSampler
 from .models import *
 
 
-def get_sampler(args, y):
-    if (args.sampler == None) or (args.sampler == 'None'):
-        sampler = None
+def get_sampler(args, dataset, y_train):
+    if args.sampler == None or args.sampler == 'None':
+        sampler = RandomSampler(dataset)
     elif args.sampler == 'weighted': 
-        labels = list(y)
+        labels = list(y_train)
         class_count = np.unique(labels, return_counts=True)[1]
         weights = 1.0 / torch.tensor([class_count[label-1] for label in labels], dtype=torch.float)
         sampler = WeightedRandomSampler(weights=weights, num_samples=len(labels), replacement=True)


### PR DESCRIPTION
`issue:` #68 
---
* 이제 weighted random sampler와 cross validation을 함께 사용할 수 있습니다.
* fold마다 train과 valid를 분할하는 방식을 기존 SubsetSampler를 사용하는 방식에서 Subset을 사용하는 방식으로 수정하였습니다.
* 이제 cross validation을 수행하면 각 fold별 minimum loss를 평균한 cv score를 print문으로 출력합니다.

테스트한 코드 목록
---
```
--model NCF --epochs 1 --sampler None
--model NCF --epochs 1 --sampler weighted
--model NCF --epochs 1 --sampler None -cv True --oof True
--model NCF --epochs 1 --sampler weighted -cv True --oof True
```